### PR TITLE
Fix createOrUpdate without locale after first time

### DIFF
--- a/src/Models/ModelTranslation.php
+++ b/src/Models/ModelTranslation.php
@@ -130,7 +130,6 @@ class ModelTranslation extends Eloquent
      */
     public function updateTranslation($type, $value, $locale = null)
     {
-        $locale = $this->getLocale($locale);
         $translation = $this->getExistingTranslation($type, $locale);
 
         $translation->value = $value;
@@ -207,6 +206,8 @@ class ModelTranslation extends Eloquent
      */
     protected function getExistingTranslation($type, $locale)
     {
+        $locale = $this->getLocale($locale);
+
         return self::where('type', $type)
             ->where('locale', $locale)
             ->where('model', get_class($this->caller))

--- a/tests/TranslatableTraitTest.php
+++ b/tests/TranslatableTraitTest.php
@@ -155,7 +155,7 @@ class TranslatableTraitTest extends TestCase
 
         $this->post->translation()->createOrUpdateSingleTranslation('title', 'Second Title Without Locale');
 
-        $this->assertNull($this->post->translation()->where('value','First Title Without Locale')->first());
-        $this->assertEquals('Second Title Without Locale',$this->post->translation()->get('title'));
+        $this->assertNull($this->post->translation()->where('value', 'First Title Without Locale')->first());
+        $this->assertEquals('Second Title Without Locale', $this->post->translation()->get('title'));
     }
 }

--- a/tests/TranslatableTraitTest.php
+++ b/tests/TranslatableTraitTest.php
@@ -145,4 +145,18 @@ class TranslatableTraitTest extends TestCase
         $this->assertTrue($this->post->translation()->clear('title'));
         $this->assertNull($this->post->translation()->get('title'));
     }
+
+    /**
+     * Target : Make sure createOrUpdateSingleTranslation() updates the translation table on second time .
+     * 
+     */
+    public function testcreateOrUpdateSingleTranslationUpdatesWithoutLocaleOnSecondTime()
+    {
+        $this->post->translation()->createOrUpdateSingleTranslation('title', 'First Title Without Locale');
+
+        $this->post->translation()->createOrUpdateSingleTranslation('title', 'Second Title Without Locale');
+        
+        $this->assertNull($this->post->translation()->where('value','First Title Without Locale')->first());
+        $this->assertEquals('Second Title Without Locale',$this->post->translation()->get('title'));
+    }
 }

--- a/tests/TranslatableTraitTest.php
+++ b/tests/TranslatableTraitTest.php
@@ -148,14 +148,13 @@ class TranslatableTraitTest extends TestCase
 
     /**
      * Target : Make sure createOrUpdateSingleTranslation() updates the translation table on second time .
-     * 
      */
     public function testcreateOrUpdateSingleTranslationUpdatesWithoutLocaleOnSecondTime()
     {
         $this->post->translation()->createOrUpdateSingleTranslation('title', 'First Title Without Locale');
 
         $this->post->translation()->createOrUpdateSingleTranslation('title', 'Second Title Without Locale');
-        
+
         $this->assertNull($this->post->translation()->where('value','First Title Without Locale')->first());
         $this->assertEquals('Second Title Without Locale',$this->post->translation()->get('title'));
     }

--- a/tests/TranslatableTraitTest.php
+++ b/tests/TranslatableTraitTest.php
@@ -154,7 +154,8 @@ class TranslatableTraitTest extends TestCase
         $this->post->translation()->createOrUpdateSingleTranslation('title', 'First Title Without Locale');
 
         $this->post->translation()->createOrUpdateSingleTranslation('title', 'Second Title Without Locale');
-
+        
+        
         $this->assertNull($this->post->translation()->where('value','First Title Without Locale')->first());
         $this->assertEquals('Second Title Without Locale',$this->post->translation()->get('title'));
     }

--- a/tests/TranslatableTraitTest.php
+++ b/tests/TranslatableTraitTest.php
@@ -154,8 +154,7 @@ class TranslatableTraitTest extends TestCase
         $this->post->translation()->createOrUpdateSingleTranslation('title', 'First Title Without Locale');
 
         $this->post->translation()->createOrUpdateSingleTranslation('title', 'Second Title Without Locale');
-        
-        
+
         $this->assertNull($this->post->translation()->where('value','First Title Without Locale')->first());
         $this->assertEquals('Second Title Without Locale',$this->post->translation()->get('title'));
     }


### PR DESCRIPTION
i was trying to update model translation after first time without locale but it was creating more translation records in database .

